### PR TITLE
GH-29 Add #organization to WebPage’s `publisher.url`

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -47,7 +47,7 @@ module.exports = ({ meta }) => {
     publisher: {
       "@type": "Organization",
       name: meta.site.name,
-      url: meta.site.url,
+      url: `${meta.site.url}#organization`,
 
       logo: image(meta.site.logo),
     },


### PR DESCRIPTION
This PR closes #29 by adding `#organization` to the `WebPage` object’s `publisher.url` value to correctly point to the `Organization` object.