### PR TITLE
feat: avoid errors when no data is available

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -49,6 +49,8 @@ const main = require("./main");
  * @returns {String}
  */
 module.exports = ({ meta, type, tags = [] }) => {
+  if (!meta) return "";
+
   const json = main({ meta, type, tags });
   const spaces = 2;
 

--- a/test/nometaTest.js
+++ b/test/nometaTest.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const test = require("ava");
+
+const script = require("../src/script.js");
+const parsedEqual = require("../utils/parsedEqual");
+
+test("no meta", (t) => {
+  const meta = undefined;
+
+  const expected = "";
+
+  parsedEqual(t, script({ meta }), expected);
+});


### PR DESCRIPTION
I had a bad dev experience when using this plugin, that I'd like to solve with this PR. This would also have prevented this similar experience from another dev: #1 

In my particular case: I'm adding the plugin, with no data at all, to a project, so that other people, at their pace, can add the actual meta data later on. I think this is a normal use case and it should work without issues. It also follows strictly the installation instructions.

I think the plugin should work straight away even when there's no data: No data, no JSON+LD.

### What I've done
Using TDD I've first added a `test/nodataTest.js` which was failing as expected. Then I fixed it by returning an empty string when the plugin is called with no `meta` on `src/script.js`.

I would also maybe warn users, and have some level of verbosity via an environment variable, or just a simple `console.warn`. But I didn't want to add too much logic to keep the PR simple.

What do you think?