### PR TITLE
feat(demo): add eleventyComputed example for site-wide schema data [skip ci]

### DIFF
--- a/demo/_data/site.json
+++ b/demo/_data/site.json
@@ -1,0 +1,10 @@
+{
+  "name": "Site title",
+  "description": "Site description",
+  "url": "https://example.com",
+  "logo": {
+    "src": "https://example.com/images/logo.png",
+    "width": 1200,
+    "height": 630
+  }
+}

--- a/demo/demo.11tydata.js
+++ b/demo/demo.11tydata.js
@@ -1,0 +1,8 @@
+export default {
+  eleventyComputed: {
+    meta: (data) => ({
+      site: data.site,
+      ...data.meta,
+    }),
+  },
+};

--- a/demo/page-computed.njk
+++ b/demo/page-computed.njk
@@ -1,0 +1,13 @@
+---
+layout: layout.njk
+type: page
+meta:
+  language: en-US
+  url: https://example.com/page
+  title: Computed page
+  description: Page description using site data from _data/site.json
+  image:
+    src: https://example.com/images/page.png
+---
+
+Page content... (site name pulled from _data/site.json via eleventyComputed)


### PR DESCRIPTION
Adds a working example showing how to avoid duplicating site info (name, description, url, logo) in every markdown file's front matter.

**Changes:**
- `demo/_data/site.json` — single source of truth for site-wide properties
- `demo/demo.11tydata.js` — directory-level `eleventyComputed` that merges `site` into each page's `meta`
- `demo/page-computed.njk` — example page with no `site` block in front matter

The existing demo pages are unaffected (their front matter `site` still wins after the spread).